### PR TITLE
Add realIp override to allow anonymous submissions

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -36,6 +36,10 @@ http {
         server_name  _;
         root         /usr/share/nginx/html;
 
+        set_real_ip_from 192.172.189.251;
+        real_ip_header X-Forwarded-For;
+        real_ip_recursive on;
+
         location / {
            try_files $uri $uri/ /index.html;
         }


### PR DESCRIPTION
This small fix should unblock the possibility of anonymous submissions (one per IP) in pybossa.
The effectiveness of this fix is related to:
* How is the X-Forwarded-For formed by your loadbalancer
* What are IP(s) of your loadbalancer (I assume it's 192.172.189.251? - that's an IP attached to task exports for anonymous user. but it's unusual since it's a public address)

I cannot help much  more without knowing the internal network topology and seeing the logs, but this fix might be enough, please let me now if it worked